### PR TITLE
refactor: don't use set-ouput as it's getting deprecated by Github

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,17 +18,17 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: auto-license
-      run: |
-        PULP_USERNAME="${{ inputs.username }}"
-        KONG_LICENSE_DATA=$(${{ github.action_path }}/auto-license.sh <<< "${{ inputs.password }}")
-        if [ $? -ne 0 ]; then
-          exit 1
-        fi
-        echo ::add-mask::$(jq -r '.license.signature' <<< "$KONG_LICENSE_DATA")
-        echo ::add-mask::$(jq -r '.license.payload.license_key' <<< "$KONG_LICENSE_DATA")
-        echo "::set-output name=license::$KONG_LICENSE_DATA"
-        echo 'KONG_LICENSE_DATA<<EOF' >> $GITHUB_ENV
-        echo $KONG_LICENSE_DATA >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
-      shell: bash
+  - id: auto-license
+    run: |
+      PULP_USERNAME="${{ inputs.username }}"
+      KONG_LICENSE_DATA=$(${{ github.action_path }}/auto-license.sh <<< "${{ inputs.password }}")
+      if [ $? -ne 0 ]; then
+        exit 1
+      fi
+      echo ::add-mask::$(jq -r '.license.signature' <<< "$KONG_LICENSE_DATA")
+      echo ::add-mask::$(jq -r '.license.payload.license_key' <<< "$KONG_LICENSE_DATA")
+      echo "license=$KONG_LICENSE_DATA" >> $GITHUB_OUTPUT
+      echo 'KONG_LICENSE_DATA<<EOF' >> $GITHUB_ENV
+      echo $KONG_LICENSE_DATA >> $GITHUB_ENV
+      echo 'EOF' >> $GITHUB_ENV
+    shell: bash


### PR DESCRIPTION
Since [Github is deprecating `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and issuing warning for workflows that use it let's change it to `echo "NAME=VALUE" >> GITHUB_OUTPUT` as suggested in https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

