### PR TITLE
Bypass biometric auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ command.
 
 Before continuing, make sure you have access to the "Shared" vault in 1Password. You can request access to this vault via the `#it` Kong slack channel. There is an example request [here](https://kongstrong.slack.com/archives/C5B4SU6KC/p1615993209037400) that can be referenced if it's not clear what is being requested from the IT team.
 
+Note that if you have configured your local 1Password with biometric security (e.g. Apple Face ID), this is not supported by the license script. You will have to add your accounts to the 1Password CLI tool [manually](https://developer.1password.com/docs/cli/sign-in-manually).
+
 ---
 
 ## Installation

--- a/license.sh
+++ b/license.sh
@@ -40,6 +40,7 @@ function cleanup {
   unset KONG_PULP_PWD KONG_PULP_USER KONG_PULP_URL
   unset NEW_KEY OLD_SIG NEW_SIG
   unset OP_SIGNIN_PARAMS OP_GET_CMD OP_SIGNOUT_PARAMS
+  unset OP_BIOMETRIC_UNLOCK_ENABLED
   unset_zsh_opts
 }
 
@@ -76,6 +77,9 @@ if [[ "$1" == "--clean" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
 
+# Disable use of biometric auth if enabled (causes issues with account names and shorthands)
+# https://developer.1password.com/docs/cli/about-biometric-unlock
+export OP_BIOMETRIC_UNLOCK_ENABLED=false
 
 #Check 1Password CLI version
 OP_VERSION=$(op --version)


### PR DESCRIPTION
`op` CLI supports authentication by use of [biometric auth devices](https://developer.1password.com/docs/cli/about-biometric-unlock) (e.g. Apple TouchID).

However when enabled this yields differences in the CLI output:
- Use of account shorthand values is not available so account name changes from `team_kong` to `team-kong`.
- A session token value is not returned from the `op signin` command.

Setting the `OP_BIOMETRIC_UNLOCK_ENABLED` envvar bypasses use of biometric authentication to prevent incompatible CLI operation.