### PR TITLE
fix(gha) since we loop, we no longer set failure exit code

### DIFF
--- a/auto-license.sh
+++ b/auto-license.sh
@@ -77,3 +77,6 @@ do
   fi
   sleep 3
 done
+
+# we failed
+exit 1


### PR DESCRIPTION
If the license download failed, we would still exit with a success exit code, which in turn wouldn't fail the action in CI.