### PR TITLE
fix(zsh): reset traps

### DIFF
--- a/license.sh
+++ b/license.sh
@@ -8,6 +8,7 @@
 function unset_zsh_opts(){
   if [[ "${SHELL}" =~ .*zsh$ && -n ${ZSH_NAME} ]]; then
     unsetopt SH_WORD_SPLIT
+    trap - EXIT INT TERM
   fi
 }
 if [[ "${SHELL}" =~ .*zsh$ && -n ${ZSH_NAME} ]]; then


### PR DESCRIPTION
When using with zsh, the `EXIT`, `INT`, and `TERM` signals are still trapped after the `source ~/.local/bin/license` command exits, which causes the `^C` unusable.

This pull request adds a `trap - EXIT INT TERM` command to fix this issue by resetting the traps.