### PR TITLE
Fix Pulp Credentials

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,1 @@
-disable=SC2181
-disable=SC2155
+disable=SC2250

--- a/license.sh
+++ b/license.sh
@@ -5,7 +5,7 @@
 # unknown flag: --account team_kong --raw
 #
 # rel: https://zsh.sourceforge.io/Doc/Release/Options.html
-function unset_zsh_opts(){
+function unset_zsh_opts() {
   if [[ "${SHELL}" =~ .*zsh$ && -n ${ZSH_NAME} ]]; then
     unsetopt SH_WORD_SPLIT
     trap - EXIT INT TERM
@@ -32,7 +32,6 @@ OP_UUID=c5jg2oc6wzg6ffs2awxeohrnmm
 FILENAME="$LOCATION/$FILE"
 KONG_PULP_URL="https://download.konghq.com/internal/kong-gateway/license.json"
 
-
 function cleanup {
   unset LOCATION FILE OP_ACCOUNT FILENAME
   unset PRODUCT COMPANY EXPIRE
@@ -44,7 +43,6 @@ function cleanup {
   unset OP_BIOMETRIC_UNLOCK_ENABLED
   unset_zsh_opts
 }
-
 
 if [[ "$1" == "--help" ]]; then
   echo "Utility to automatically set the Kong Enterprise license"
@@ -69,10 +67,9 @@ if [[ "$1" == "--help" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
 
-
 if [[ "$1" == "--clean" ]]; then
-  rm "$FILENAME"  > /dev/null 2>&1
-  rmdir "$LOCATION"  > /dev/null 2>&1
+  rm "$FILENAME" >/dev/null 2>&1
+  rmdir "$LOCATION" >/dev/null 2>&1
   echo "Removed cached files"
   cleanup
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
@@ -124,7 +121,7 @@ elif [[ $OP_VERSION != 2* ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
 
-jq --version > /dev/null 2>&1
+jq --version >/dev/null 2>&1
 if [[ $? -ne 0 ]]; then
   echo "Utility 'jq' was not found, please make sure it is installed"
   echo "and available in the system path."
@@ -134,7 +131,6 @@ if [[ $? -ne 0 ]]; then
   cleanup
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
-
 
 # check if we're sourced or run
 if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
@@ -146,12 +142,10 @@ if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
   echo
 fi
 
-
 # create directory if it doesn't exist
 if [[ ! -d "$LOCATION" ]]; then
   mkdir "$LOCATION"
 fi
-
 
 # create outdated license if it doesn't exist
 if [[ ! -f "$FILENAME" ]]; then
@@ -162,14 +156,12 @@ EOL
   chmod +x "$FILENAME"
 fi
 
-
 # set the license data
 export KONG_LICENSE_DATA=$(<"$FILENAME")
-PRODUCT=$(jq -r '.license.payload.product_subscription' <<< "$KONG_LICENSE_DATA")
-COMPANY=$(jq -r '.license.payload.customer' <<< "$KONG_LICENSE_DATA")
-EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<< "$KONG_LICENSE_DATA")
+PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
+COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
+EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")
 echo "$PRODUCT licensed to $COMPANY, license expires: $EXPIRE"
-
 
 # Parsing date is platform specific
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -193,10 +185,9 @@ else
   WARN_EPOCH=$(date -v +10d +%s)
 fi
 
-
-if (( NOW_EPOCH < EXPIRE_EPOCH )); then
+if ((NOW_EPOCH < EXPIRE_EPOCH)); then
   # license still valid
-  if (( WARN_EPOCH > EXPIRE_EPOCH )); then
+  if ((WARN_EPOCH > EXPIRE_EPOCH)); then
     # Expiry is within 10 days
     EXPIRE_IN=$((EXPIRE_EPOCH - NOW_EPOCH))
     EXPIRE_IN=$((EXPIRE_IN / 86400))
@@ -234,7 +225,7 @@ echo
 # sign in to 1Password
 echo "Logging into 1Password..."
 OP_TOKEN=$(
-  # shellcheck disable=SC2086 
+  # shellcheck disable=SC2086
   op signin $OP_SIGNIN_PARAMS
 )
 if [[ ! $? == 0 ]]; then
@@ -261,7 +252,7 @@ fi
 
 # sign out again
 echo "Sign out of 1Password..."
-# shellcheck disable=SC2086 
+# shellcheck disable=SC2086
 op signout $OP_SIGNOUT_PARAMS
 
 echo "Downloading license..."
@@ -273,7 +264,6 @@ if [[ ! $NEW_KEY == *"signature"* || ! $NEW_KEY == *"payload"* ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
 fi
 
-
 # validate it is different
 OLD_SIG=$(jq -r '.license.signature' <<<"$KONG_LICENSE_DATA")
 NEW_SIG=$(jq -r '.license.signature' <<<"$NEW_KEY")
@@ -284,13 +274,13 @@ if [[ "$OLD_SIG" == "$NEW_SIG" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
 fi
 
-echo "$NEW_KEY" > "$FILENAME"
+echo "$NEW_KEY" >"$FILENAME"
 echo license updated!
 
 # set the license data
 export KONG_LICENSE_DATA=$(<"$FILENAME")
-PRODUCT=$(jq -r '.license.payload.product_subscription' <<< "$KONG_LICENSE_DATA")
-COMPANY=$(jq -r '.license.payload.customer' <<< "$KONG_LICENSE_DATA")
-EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<< "$KONG_LICENSE_DATA")
+PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
+COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
+EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")
 echo "$PRODUCT licensed to $COMPANY, license expires: $EXPIRE"
 cleanup

--- a/license.sh
+++ b/license.sh
@@ -79,9 +79,8 @@ fi
 # https://developer.1password.com/docs/cli/about-biometric-unlock
 export OP_BIOMETRIC_UNLOCK_ENABLED=false
 
-#Check 1Password CLI version
-OP_VERSION=$(op --version)
-if [[ $? -ne 0 ]]; then
+# Check 1Password CLI available
+if ! op --version >/dev/null 2>&1; then
   echo "The 1Password CLI utility 'op' was not found"
   echo "Please download and do the initial signin"
   echo
@@ -99,7 +98,8 @@ OP_SIGNIN_PARAMS="--account $OP_ACCOUNT --raw"
 OP_GET_CMD="item get"
 OP_SIGNOUT_PARAMS=""
 
-# Crude version check and set parameters to match
+# Check 1Password CLI version
+OP_VERSION="$(op --version)"
 if [[ $OP_VERSION == 1* ]]; then
   echo "Found 1Password CLI v1"
   echo "Please upgrade to v2"
@@ -157,7 +157,8 @@ EOL
 fi
 
 # set the license data
-export KONG_LICENSE_DATA=$(<"$FILENAME")
+KONG_LICENSE_DATA=$(<"$FILENAME")
+export KONG_LICENSE_DATA
 PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
 COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
 EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")
@@ -278,7 +279,8 @@ echo "$NEW_KEY" >"$FILENAME"
 echo license updated!
 
 # set the license data
-export KONG_LICENSE_DATA=$(<"$FILENAME")
+KONG_LICENSE_DATA=$(<"$FILENAME")
+export KONG_LICENSE_DATA
 PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
 COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
 EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")

--- a/license.sh
+++ b/license.sh
@@ -104,16 +104,15 @@ OP_SIGNOUT_PARAMS=""
 
 # Crude version check and set parameters to match
 if [[ $OP_VERSION == 1* ]]; then
-  echo "[INFO] Found 1Password CLI v1"
-  echo "[INFO] Please upgrade to v2 for longer support"
-  echo "[INFO] https://1password.com/downloads/command-line/"
-  #Set for op_CLIv1
-  OP_SIGNIN_PARAMS="$OP_ACCOUNT --output=raw"
-  OP_GET_CMD="get item"
-  OP_SIGNOUT_PARAMS="--session=$OP_TOKEN"
+  echo "Found 1Password CLI v1"
+  echo "Please upgrade to v2"
+  echo "https://1password.com/downloads/command-line/"
+  echo
+  cleanup
+  [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 elif [[ $OP_VERSION != 2* ]]; then
   echo "The 1Password CLI utility 'op' version found is not supported by this script"
-  echo "Currently supporting v1 (legacy) and v2 (latest as of 2022-05)"
+  echo "Currently supporting only v2 (latest as of 2023-03)"
   echo "Please download v2 and do the initial signin"
   echo
   echo "See: https://1password.com/downloads/command-line/"
@@ -264,15 +263,6 @@ fi
 echo "Sign out of 1Password..."
 # shellcheck disable=SC2086 
 op signout $OP_SIGNOUT_PARAMS
-
-#Extract UID and PWD from 1Password response depending on version
-if [[ $OP_VERSION == 1* ]]; then
-  KONG_PULP_PWD=$(printf "%s" "$DETAILS" | jq '.details.fields[]? | select(.designation=="password").value' | sed s/\"//g)
-  KONG_PULP_USER=$(printf "%s" "$DETAILS" | jq '.details.fields[]? | select(.designation=="username").value' | sed s/\"//g)
-elif [[ $OP_VERSION == 2* ]]; then
-  KONG_PULP_PWD=$(printf "%s" "$DETAILS" | jq '.fields[]? | select(.id=="password").value' | sed s/\"//g)
-  KONG_PULP_USER=$(printf "%s" "$DETAILS" | jq '.fields[]? | select(.id=="username").value' | sed s/\"//g)
-fi
 
 echo "Downloading license..."
 NEW_KEY=$(curl -s -L -u"$KONG_PULP_USER:$KONG_PULP_PWD" "$KONG_PULP_URL")

--- a/license.sh
+++ b/license.sh
@@ -212,15 +212,22 @@ fi
 
 echo
 echo "Downloading license..."
+
+TMP_FILENAME="$(mktemp)"
+
 # shellcheck disable=SC2154
-NEW_KEY="$(
-  op run --env-file=<(
-    echo 'USERNAME=op://Shared/License Credentials/username'
-    echo 'PASSWORD=op://Shared/License Credentials/password'
-  ) -- bash -xc "
-    curl -s -L -u\"\${USERNAME}:\${PASSWORD}\" \"\${PULP_URL}\"
-  "
-)"
+
+op run --env-file=<(
+  echo 'USERNAME=op://Shared/License Credentials/username'
+  echo 'PASSWORD=op://Shared/License Credentials/password'
+) -- bash -xc "
+  curl -sL \
+    -u \"\${USERNAME}:\${PASSWORD}\" \
+    \"\${PULP_URL}\" \
+    -o \"${TMP_FILENAME}\"
+"
+
+NEW_KEY="$(cat "$TMP_FILENAME")"
 
 if [[ ! $NEW_KEY == *"signature"* || ! $NEW_KEY == *"payload"* ]]; then
   echo "[ERROR] failed to download the Kong Enterprise license file


### PR DESCRIPTION
This PR accomplishes a number of goals:
- remove support for the 1Password CLI version 1 (deprecated now for quite some time)
- remove all `op signin`/`op signin`: this causes the `op run` towards the end to prompt the user if not already signed in
- avoid using `op item get` and parsing JSON data from it in the shell
- utilize the new old 1P item by name/URI-style, which avoids needing to update the item's UID in the future