### PR TITLE
Store license directly in 1Password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+---
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - "**/*.sh"
+      - "Makefile"
+      - ".shellcheckrc"
+      - "action.yml"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make lint
+
+  functional:
+    name: Functional Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-dist: bionic
-
-script:
-- make lint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kong Inc. internal test license script
 
+[![CI](https://github.com/Kong/kong-license/actions/workflows/ci.yml/badge.svg)](https://github.com/Kong/kong-license/actions/workflows/ci.yml)
+
 There are 3 scripts/actions;
 
 1. [user script](#user-script)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The shortest version relying on defaults and environment variables being set:
 steps:
   - uses: Kong/kong-license@master
     with:
-      password: ${{ secrets.PULP_PASSWORD }}
+      op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   - run: kong start
     shell: bash
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ There are 3 scripts/actions;
 1. [user script](#user-script)
 2. [automation script](#automation-script)
 3. [github action](#github-action)
+4. [directly via 1Password](#1password-directly)
 
 ## User script
 
@@ -131,6 +132,15 @@ steps:
       op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   - run: kong start
     shell: bash
+```
+
+### 1Password Directly
+
+The scripts and tooling in this repo, including the github action, are wrappers around 1Password Inc. provided tooling. Assuming your 1Password CLI is configured correctly, the below will output the valid license, bypassing this repo's tooling altogether. Your individual 1Password user will need access to the vault of course.
+
+```shell
+$ op read 'op://Github Actions/Monthly Kong Gateway Enterprise License/license key'
+{"license":{"payload":{"admin_seats":"<snip>
 ```
 
 ### Uploading a license

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ command.
 
 ### 1Password Shared Vault Access
 
-Before continuing, make sure you have access to the "Github Actions" vault in 1Password. You can request access to this vault via the `#it` Kong slack channel. There is an example request [here](https://kongstrong.slack.com/archives/C5B4SU6KC/p1615993209037400) that can be referenced if it's not clear what is being requested from the IT team.
-
-Note that if you have configured your local 1Password with biometric security (e.g. Apple Face ID), this is not supported by the license script. You will have to add your accounts to the 1Password CLI tool [manually](https://developer.1password.com/docs/cli/sign-in-manually).
+Before continuing, make sure you have access to the "Github Actions" vault in 1Password. You can request access to this vault via [Kong's IT ServiceDesk](https://kong.freshservice.com/support/home).
 
 ### Installation
 

--- a/action.yaml
+++ b/action.yaml
@@ -18,24 +18,26 @@ inputs:
 outputs:
   license:
     description: "Kong license"
-    value: ${{ steps.auto-license.outputs.license }}
+    value: ${{ steps.onep.outputs.KONG_LICENSE_DATA }}
 
 runs:
   using: "composite"
   steps:
-    - name: "Install 1Password CLI"
-      uses: 1password/install-cli-action@v1
-    - id: "auto-license"
+    - name: Load license
+      id: onep
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: false
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-token }}
+        KONG_LICENSE_DATA: "op://Github Actions/Monthly Kong Gateway Enterprise License/license key"
+
+    - name: Mask
+      env:
+        KONG_LICENSE_DATA: ${{ steps.onep.outputs.KONG_LICENSE_DATA }}
       run: |
-        KONG_LICENSE_DATA=$(${{ github.action_path }}/auto-license.sh)
-        if [ $? -ne 0 ]; then
-          exit 1
-        fi
         echo ::add-mask::$(jq -r '.license.signature' <<< "$KONG_LICENSE_DATA")
         echo ::add-mask::$(jq -r '.license.payload.license_key' <<< "$KONG_LICENSE_DATA")
-        echo "license=$KONG_LICENSE_DATA" >> $GITHUB_OUTPUT
         echo 'KONG_LICENSE_DATA<<EOF' >> $GITHUB_ENV
         echo $KONG_LICENSE_DATA >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV

--- a/action.yaml
+++ b/action.yaml
@@ -1,13 +1,18 @@
-name: 'Kong License'
-description: 'Fetches the Kong enterprise license for Kong CI systems'
+name: "Kong License"
+description: "Fetches the Kong enterprise license for Kong CI systems"
 
 inputs:
   username:
-    description: 'Pulp username'
-    required: true
-    default: 'admin'
+    description: "Pulp username"
+    required: false
+    default: "admin"
+    deprecationMessage: "input ignored for compat"
   password:
-    description: 'Pulp password'
+    description: "Pulp password"
+    required: false
+    deprecationMessage: "input ignored for compat"
+  op-token:
+    description: "1Password Service Account token"
     required: true
 
 outputs:
@@ -18,17 +23,20 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - id: auto-license
-    run: |
-      PULP_USERNAME="${{ inputs.username }}"
-      KONG_LICENSE_DATA=$(${{ github.action_path }}/auto-license.sh <<< "${{ inputs.password }}")
-      if [ $? -ne 0 ]; then
-        exit 1
-      fi
-      echo ::add-mask::$(jq -r '.license.signature' <<< "$KONG_LICENSE_DATA")
-      echo ::add-mask::$(jq -r '.license.payload.license_key' <<< "$KONG_LICENSE_DATA")
-      echo "license=$KONG_LICENSE_DATA" >> $GITHUB_OUTPUT
-      echo 'KONG_LICENSE_DATA<<EOF' >> $GITHUB_ENV
-      echo $KONG_LICENSE_DATA >> $GITHUB_ENV
-      echo 'EOF' >> $GITHUB_ENV
-    shell: bash
+    - name: "Install 1Password CLI"
+      uses: 1password/install-cli-action@v1
+    - id: "auto-license"
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-token }}
+      run: |
+        KONG_LICENSE_DATA=$(${{ github.action_path }}/auto-license.sh)
+        if [ $? -ne 0 ]; then
+          exit 1
+        fi
+        echo ::add-mask::$(jq -r '.license.signature' <<< "$KONG_LICENSE_DATA")
+        echo ::add-mask::$(jq -r '.license.payload.license_key' <<< "$KONG_LICENSE_DATA")
+        echo "license=$KONG_LICENSE_DATA" >> $GITHUB_OUTPUT
+        echo 'KONG_LICENSE_DATA<<EOF' >> $GITHUB_ENV
+        echo $KONG_LICENSE_DATA >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: "bash"

--- a/action.yaml
+++ b/action.yaml
@@ -6,11 +6,11 @@ inputs:
     description: "Pulp username"
     required: false
     default: "admin"
-    deprecationMessage: "input ignored for compat"
+    deprecationMessage: "pulp no longer used, only 'op-token' is needed"
   password:
     description: "Pulp password"
     required: false
-    deprecationMessage: "input ignored for compat"
+    deprecationMessage: "pulp no longer used, only 'op-token' is needed"
   op-token:
     description: "1Password Service Account token"
     required: true

--- a/auto-license.sh
+++ b/auto-license.sh
@@ -1,68 +1,71 @@
 #!/usr/bin/env bash
 
 # Script that sends tha Kong license to stdout. The license will be downloaded
-# from Pulp.
+# from 1Password.
 #
-# Inputs:
-#   stdin, or PULP_PASSWORD env var: required
-#   PULP_USERNAME env var, defaults to 'admin' if not set
+# Inputs: none
 #
 # Dependencies:
-#   curl: required
+#   op: (1Password CLI) required
 #   jq: optional, will print some license details if available
 
+OP_UUID='ddwtjd6cmytlksanwl6xtkw23a'
+
+# OnePassword account name
+OP_ACCOUNT=team_kong
+
+OP_SIGNIN_PARAMS="--account $OP_ACCOUNT --raw"
+OP_GET_CMD="item get"
+
 function main {
-  local KONG_PULP_PASSWORD
-  local KONG_PULP_USERNAME=admin
-  local KONG_PULP_URL="https://download.konghq.com/internal/kong-gateway/license.json"
   local KONG_LICENSE_DATA
 
-  if ! curl --version > /dev/null ; then
-    echo "[ERROR] required dependency 'curl' missing" 1>&2
-    exit 1
+  # sign in to 1Password
+  echo "Logging into 1Password..."
+  OP_TOKEN=$(
+    # shellcheck disable=SC2086
+    op signin ${OP_SIGNIN_PARAMS}
+  )
+  if [[ ! $? == 0 ]]; then
+    # an error while logging into 1Password
+    echo "[ERROR] Failed to get a 1Password token, license data not updated."
+    cleanup
+    [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
   fi
 
-  if [ -t 0 ]; then
-    # running interactively
-    if [ -z "$PULP_PASSWORD" ]; then
-      echo "PULP_PASSWORD not set, nor passed in on STDIN" 1>&2
-      exit 1
-    fi
-    KONG_PULP_PASSWORD=$PULP_PASSWORD
-  else
-    # pipe stdin; read password
-    IFS= read -r KONG_PULP_PASSWORD
+  # Get the gateway license
+  echo "Get license file from 1Password..."
+  DETAILS=$(
+    # shellcheck disable=SC2086
+    op ${OP_GET_CMD} "$OP_UUID" --session "$OP_TOKEN" --format json
+  )
+  if [[ ! $? == 0 ]]; then
+    # an error while fetching from 1p
+    echo "[ERROR] Failed to get the data from 1Password, license data not updated."
+    # sign out again
+    op signout
+    cleanup
+    [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
   fi
 
-  if [ -n "$PULP_USERNAME" ]; then
-    KONG_PULP_USERNAME=$PULP_USERNAME
-  fi
-
-
-  KONG_LICENSE_DATA=$(curl --fail -s -L -u"$KONG_PULP_USERNAME:$KONG_PULP_PASSWORD" "$KONG_PULP_URL")
-  CURL_RETURN_CODE=$?
-  if [[ ${CURL_RETURN_CODE} -ne 0 ]]; then
-    echo "[ERROR] failed to download the Kong Enterprise license file, curl failed with error code ${CURL_RETURN_CODE}" 1>&2
-    return 1
-  fi
-
+  KONG_LICENSE_DATA="$DETAILS"
   if [[ ! ${KONG_LICENSE_DATA} == *"signature"* || ! ${KONG_LICENSE_DATA} == *"payload"* ]]; then
     echo "[ERROR] failed to download the Kong Enterprise license file
 ${KONG_LICENSE_DATA}" 1>&2
     return 1
   fi
 
-  if ! jq <<< "${KONG_LICENSE_DATA}" &> /dev/null ; then
+  if ! jq <<<"${KONG_LICENSE_DATA}" &>/dev/null; then
     echo "[ERROR] downloaded Kong Enterprise license is not a valid JSON:
 ${KONG_LICENSE_DATA}" 1>&2
     return 1
   fi
 
-  if jq --version &> /dev/null ; then
+  if jq --version &>/dev/null; then
     # jq is installed so do some pretty printing of license info (to STDERR)
-    local PRODUCT=$(jq -r '.license.payload.product_subscription' <<< "${KONG_LICENSE_DATA}")
-    local COMPANY=$(jq -r '.license.payload.customer' <<< "${KONG_LICENSE_DATA}")
-    local EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<< "${KONG_LICENSE_DATA}")
+    local PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"${KONG_LICENSE_DATA}")
+    local COMPANY=$(jq -r '.license.payload.customer' <<<"${KONG_LICENSE_DATA}")
+    local EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"${KONG_LICENSE_DATA}")
     echo "$PRODUCT licensed to $COMPANY, license expires: $EXPIRE" 1>&2
   fi
 
@@ -70,8 +73,7 @@ ${KONG_LICENSE_DATA}" 1>&2
 }
 
 # Add some basic retry mechanism to work around network flakiness and/or API misbehavior.
-for _ in {1..3}
-do
+for _ in {1..3}; do
   if main; then
     exit 0
   fi

--- a/auto-license.sh
+++ b/auto-license.sh
@@ -12,7 +12,7 @@
 OP_UUID='ddwtjd6cmytlksanwl6xtkw23a'
 
 # OnePassword account name
-OP_ACCOUNT=team_kong
+OP_ACCOUNT='team-kong.1password.com'
 
 OP_SIGNIN_PARAMS="--account $OP_ACCOUNT --raw"
 OP_GET_CMD="item get"

--- a/auto-license.sh
+++ b/auto-license.sh
@@ -22,10 +22,10 @@ function main {
 
   # sign in to 1Password
   echo "Logging into 1Password..."
-  OP_TOKEN=$(
-    # shellcheck disable=SC2086
-    op signin ${OP_SIGNIN_PARAMS}
-  )
+
+  # shellcheck disable=SC2086
+  op signin ${OP_SIGNIN_PARAMS}
+
   if [[ ! $? == 0 ]]; then
     # an error while logging into 1Password
     echo "[ERROR] Failed to get a 1Password token, license data not updated."
@@ -37,7 +37,11 @@ function main {
   echo "Get license file from 1Password..."
   DETAILS=$(
     # shellcheck disable=SC2086
-    op ${OP_GET_CMD} "$OP_UUID" --session "$OP_TOKEN" --format json
+    op $OP_GET_CMD \
+      $OP_UUID \
+      --fields label=reg_code \
+      --format json |
+      jq -r '.value'
   )
   if [[ ! $? == 0 ]]; then
     # an error while fetching from 1p

--- a/license.sh
+++ b/license.sh
@@ -23,7 +23,7 @@ LOCATION="${HOME}/.kong-license-data"
 FILE='license.json'
 
 # OnePassword account name
-OP_ACCOUNT=team_kong
+OP_ACCOUNT='team-kong.1password.com'
 
 # License entry uuid, use:
 #   op item get --vault 'Github Actions' 'Monthly Kong Gateway Enterprise License' | grep 'ID:'

--- a/license.sh
+++ b/license.sh
@@ -101,13 +101,12 @@ OP_SIGNOUT_PARAMS=""
 
 # Crude version check and set parameters to match
 if [[ $OP_VERSION == 1* ]]; then
-  echo "[INFO] Found 1Password CLI v1"
-  echo "[INFO] Please upgrade to v2 for longer support"
-  echo "[INFO] https://1password.com/downloads/command-line/"
-  # Set for op_CLIv1
-  OP_SIGNIN_PARAMS="$OP_ACCOUNT --output=raw"
-  OP_GET_CMD="get item"
-  OP_SIGNOUT_PARAMS="--session=$OP_TOKEN"
+  echo "[ERROR] Found 1Password CLI v1"
+  echo "[ERROR] Please upgrade to v2"
+  echo "[ERROR] https://1password.com/downloads/command-line/"
+  echo
+  cleanup
+  exit 1
 elif [[ $OP_VERSION != 2* ]]; then
   echo "The 1Password CLI utility 'op' version found is not supported by this script"
   echo "Currently supporting v1 (legacy) and v2 (latest as of 2022-05)"

--- a/license.sh
+++ b/license.sh
@@ -5,7 +5,7 @@
 # unknown flag: --account team_kong --raw
 #
 # rel: https://zsh.sourceforge.io/Doc/Release/Options.html
-function unset_zsh_opts(){
+function unset_zsh_opts() {
   if [[ "${SHELL}" =~ .*zsh$ && -n ${ZSH_NAME} ]]; then
     unsetopt SH_WORD_SPLIT
     trap - EXIT INT TERM
@@ -32,7 +32,6 @@ OP_UUID=qmcno52ta6oa2wkyeg3ta5466u
 FILENAME="$LOCATION/$FILE"
 KONG_PULP_URL="https://download.konghq.com/internal/kong-gateway/license.json"
 
-
 function cleanup {
   unset LOCATION FILE OP_ACCOUNT FILENAME
   unset PRODUCT COMPANY EXPIRE
@@ -44,7 +43,6 @@ function cleanup {
   unset OP_BIOMETRIC_UNLOCK_ENABLED
   unset_zsh_opts
 }
-
 
 if [[ "$1" == "--help" ]]; then
   echo "Utility to automatically set the Kong Enterprise license"
@@ -69,10 +67,9 @@ if [[ "$1" == "--help" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
 
-
 if [[ "$1" == "--clean" ]]; then
-  rm "$FILENAME"  > /dev/null 2>&1
-  rmdir "$LOCATION"  > /dev/null 2>&1
+  rm "$FILENAME" >/dev/null 2>&1
+  rmdir "$LOCATION" >/dev/null 2>&1
   echo "Removed cached files"
   cleanup
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
@@ -125,7 +122,7 @@ elif [[ $OP_VERSION != 2* ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
 
-jq --version > /dev/null 2>&1
+jq --version >/dev/null 2>&1
 if [[ $? -ne 0 ]]; then
   echo "Utility 'jq' was not found, please make sure it is installed"
   echo "and available in the system path."
@@ -135,7 +132,6 @@ if [[ $? -ne 0 ]]; then
   cleanup
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 0 || exit 0
 fi
-
 
 # check if we're sourced or run
 if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
@@ -147,12 +143,10 @@ if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
   echo
 fi
 
-
 # create directory if it doesn't exist
 if [[ ! -d "$LOCATION" ]]; then
   mkdir "$LOCATION"
 fi
-
 
 # create outdated license if it doesn't exist
 if [[ ! -f "$FILENAME" ]]; then
@@ -163,14 +157,12 @@ EOL
   chmod +x "$FILENAME"
 fi
 
-
 # set the license data
 export KONG_LICENSE_DATA=$(<"$FILENAME")
-PRODUCT=$(jq -r '.license.payload.product_subscription' <<< "$KONG_LICENSE_DATA")
-COMPANY=$(jq -r '.license.payload.customer' <<< "$KONG_LICENSE_DATA")
-EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<< "$KONG_LICENSE_DATA")
+PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
+COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
+EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")
 echo "$PRODUCT licensed to $COMPANY, license expires: $EXPIRE"
-
 
 # Parsing date is platform specific
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -194,10 +186,9 @@ else
   WARN_EPOCH=$(date -v +10d +%s)
 fi
 
-
-if (( NOW_EPOCH < EXPIRE_EPOCH )); then
+if ((NOW_EPOCH < EXPIRE_EPOCH)); then
   # license still valid
-  if (( WARN_EPOCH > EXPIRE_EPOCH )); then
+  if ((WARN_EPOCH > EXPIRE_EPOCH)); then
     # Expiry is within 10 days
     EXPIRE_IN=$((EXPIRE_EPOCH - NOW_EPOCH))
     EXPIRE_IN=$((EXPIRE_IN / 86400))
@@ -235,7 +226,7 @@ echo
 # sign in to 1Password
 echo "Logging into 1Password..."
 OP_TOKEN=$(
-  # shellcheck disable=SC2086 
+  # shellcheck disable=SC2086
   op signin $OP_SIGNIN_PARAMS
 )
 if [[ ! $? == 0 ]]; then
@@ -248,7 +239,7 @@ fi
 # Get the Pulp credentials
 echo "Get credentials from 1Password..."
 DETAILS=$(
-  # shellcheck disable=SC2086 
+  # shellcheck disable=SC2086
   op $OP_GET_CMD $OP_UUID --session $OP_TOKEN --format json
 )
 if [[ ! $? == 0 ]]; then
@@ -262,7 +253,7 @@ fi
 
 # sign out again
 echo "Sign out of 1Password..."
-# shellcheck disable=SC2086 
+# shellcheck disable=SC2086
 op signout $OP_SIGNOUT_PARAMS
 
 #Extract UID and PWD from 1Password response depending on version
@@ -283,7 +274,6 @@ if [[ ! $NEW_KEY == *"signature"* || ! $NEW_KEY == *"payload"* ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
 fi
 
-
 # validate it is different
 OLD_SIG=$(jq -r '.license.signature' <<<"$KONG_LICENSE_DATA")
 NEW_SIG=$(jq -r '.license.signature' <<<"$NEW_KEY")
@@ -294,13 +284,13 @@ if [[ "$OLD_SIG" == "$NEW_SIG" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && return 1 || exit 1
 fi
 
-echo "$NEW_KEY" > "$FILENAME"
+echo "$NEW_KEY" >"$FILENAME"
 echo license updated!
 
 # set the license data
 export KONG_LICENSE_DATA=$(<"$FILENAME")
-PRODUCT=$(jq -r '.license.payload.product_subscription' <<< "$KONG_LICENSE_DATA")
-COMPANY=$(jq -r '.license.payload.customer' <<< "$KONG_LICENSE_DATA")
-EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<< "$KONG_LICENSE_DATA")
+PRODUCT=$(jq -r '.license.payload.product_subscription' <<<"$KONG_LICENSE_DATA")
+COMPANY=$(jq -r '.license.payload.customer' <<<"$KONG_LICENSE_DATA")
+EXPIRE=$(jq -r '.license.payload.license_expiration_date' <<<"$KONG_LICENSE_DATA")
 echo "$PRODUCT licensed to $COMPANY, license expires: $EXPIRE"
 cleanup


### PR DESCRIPTION
This PR is a largish overhaul of this repo to accommodate the storage of the short-lived enterprise license in 1Password directly.
This PR also swaps the defunct Travis config for a similar-ish GHA analogue.

Both the shells scripts and the github action will be effected. Unfortunately, I could not find a way to transparently inject the appropriate 1P token across all the existing repos that utilize the github action. Changes will be required to (repos):

- All descendents of Kong/kong-plugin
- Kong/deck
- Kong/kubernetes-ingress-controller
- Kong/kubernetes-testing-framework
- A handful of others

I desperately don't want to disrupt CI/testing in those repos.. so changes will need to occur in them before this can be merged :/

https://konghq.atlassian.net/browse/KAG-3254