### PR TITLE
chore(ci): bump 1password/load-secrets-action to v2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Load license
       id: onep
-      uses: 1password/load-secrets-action@v1
+      uses: 1password/load-secrets-action@v2
       with:
         export-env: false
       env:


### PR DESCRIPTION
Relevant release: https://github.com/1Password/load-secrets-action/releases/tag/v2.0.0

This will get rid of 

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: 1password/load-secrets-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

warning which is present in all workflows that rely on `kong-license`.