### PR TITLE
chore(ci): bump 1password/load-secrets-action to 3.2.1 and pin the dependency

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Load license
       id: onep
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: false
       env:


### PR DESCRIPTION
The only breaking change in [3.0.0](https://github.com/1Password/load-secrets-action/releases/tag/v3.0.0) is related to `export-env` being now set to `false` which we already do.

Address warnings in GHA:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: 1password/load-secrets-action@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
