### PR TITLE
chore(runtime): bump node.js to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - "**/*.sh"
       - "Makefile"
       - ".shellcheckrc"
-      - "action.yml"
+      - "action.yaml"
   workflow_dispatch:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: make lint
 
   functional:
@@ -24,7 +24,7 @@ jobs:
     name: Functional Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Load license
       id: onep
-      uses: 1password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
+      uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
       with:
         export-env: false
       env:


### PR DESCRIPTION
Raise the repository runtime baseline to Node.js 24. Align the version pin, package engines, and custom action runtimes on the same major version.

Background: 

> Node.js 20 actions are deprecated.
>
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
>
> Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24.
> 
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> 
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/